### PR TITLE
Fix expires number precision on iOS

### DIFF
--- a/ios/Classes/FacebookLoginPlugin.m
+++ b/ios/Classes/FacebookLoginPlugin.m
@@ -172,7 +172,7 @@
   NSArray *permissions = [accessToken.permissions allObjects];
   NSArray *declinedPermissions = [accessToken.declinedPermissions allObjects];
   NSNumber *expires = [NSNumber
-      numberWithLong:accessToken.expirationDate.timeIntervalSince1970 * 1000.0];
+      numberWithLongLong:accessToken.expirationDate.timeIntervalSince1970 * 1000.0L];
 
   return @{
     @"token" : accessToken.tokenString,


### PR DESCRIPTION
On 32bit devices (iPhone 5 and older) the expiration date overflows at the moment.
So to prevent this I changed expires to accept a longlong to make sure the value gets preserved